### PR TITLE
Add python venv to profile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,8 @@ USER $USERNAME
 
 ## Get pip as user. Create a user level python virtual environemnt.
 RUN python3 -m venv /app/docker_venv \
-    && chmod +x /app/docker_venv/bin/activate \
     && . /app/docker_venv/bin/activate \
-    && python3 /home/$USERNAME/get-pip.py
+    && python3 /home/$USERNAME/get-pip.py \
+    && echo ". /app/docker_venv/bin/activate" >> /home/$USERNAME/.bashrc
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Finally a working model of starting a docker image with pythin venv activated.
This now uses CMD bash and the user profile to source the venv activate file.